### PR TITLE
fix: 16 verified bug fixes (security, correctness, build)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -43,6 +43,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
+        <!-- B24: Bean Validation (@Size/@Valid) so over-long profile fields 400 instead of 500 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>

--- a/backend/src/main/java/at/ac/fhcampuswien/application/ApplicationController.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/application/ApplicationController.java
@@ -169,7 +169,13 @@ public class ApplicationController {
         }
 
         JobApplication updatedApplication =
-                jobApplicationRepository.updateStatus(id, newStatus);
+                jobApplicationRepository.updateStatusFrom(id, "PENDING", newStatus);
+
+        if (updatedApplication == null) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of(
+                    "error", "application is no longer PENDING"
+            ));
+        }
 
         return ResponseEntity.ok(updatedApplication);
     }
@@ -207,7 +213,13 @@ public class ApplicationController {
         }
 
         JobApplication hiredApplication =
-                jobApplicationRepository.updateStatus(id, "HIRED");
+                jobApplicationRepository.updateStatusFrom(id, "ACCEPTED", "HIRED");
+
+        if (hiredApplication == null) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of(
+                    "error", "application is no longer ACCEPTED"
+            ));
+        }
 
         // TODO: trigger contract creation via ContractService once contract/ is implemented.
 

--- a/backend/src/main/java/at/ac/fhcampuswien/application/ApplicationController.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/application/ApplicationController.java
@@ -57,10 +57,18 @@ public class ApplicationController {
             ));
         }
 
-        JobApplication savedApplication =
-                jobApplicationRepository.create(jobId, designerId, application.coverLetter);
+        try {
+            JobApplication savedApplication =
+                    jobApplicationRepository.create(jobId, designerId, application.coverLetter);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(savedApplication);
+            return ResponseEntity.status(HttpStatus.CREATED).body(savedApplication);
+        } catch (DuplicateApplicationException e) {
+            // The up-front check above races with concurrent applies; the UNIQUE
+            // constraint is the backstop, mapped to 409 here.
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of(
+                    "error", "you have already applied to this job"
+            ));
+        }
     }
 
     // GET  /jobs/{jobId}/applications       → client lists received applications

--- a/backend/src/main/java/at/ac/fhcampuswien/application/DuplicateApplicationException.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/application/DuplicateApplicationException.java
@@ -1,0 +1,9 @@
+package at.ac.fhcampuswien.application;
+
+// Thrown when an INSERT hits the UNIQUE (job_id, designer_id) constraint — a duplicate apply.
+// Lets the controller answer 409 instead of leaking a 500 on the create-race.
+public class DuplicateApplicationException extends RuntimeException {
+    public DuplicateApplicationException() {
+        super("designer has already applied to this job");
+    }
+}

--- a/backend/src/main/java/at/ac/fhcampuswien/application/JobApplicationRepository.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/application/JobApplicationRepository.java
@@ -190,6 +190,35 @@ public class JobApplicationRepository {
         }
     }
 
+    // Atomic conditional transition: flips the status only if it still equals expectedStatus.
+    // Returns the updated row, or null if the precondition no longer holds (concurrent change) — B19.
+    public JobApplication updateStatusFrom(String id, String expectedStatus, String newStatus) {
+        String sql = """
+            UPDATE applications
+            SET status = ?
+            WHERE id = ? AND status = ?
+        """;
+
+        try (Connection connection = Database.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setString(1, newStatus);
+            statement.setString(2, id);
+            statement.setString(3, expectedStatus);
+
+            int updatedRows = statement.executeUpdate();
+
+            if (updatedRows == 0) {
+                return null;
+            }
+
+            return findById(id);
+
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to update application status", e);
+        }
+    }
+
     private JobApplication mapResultSetToApplication(ResultSet resultSet) throws SQLException {
         JobApplication application = new JobApplication();
 

--- a/backend/src/main/java/at/ac/fhcampuswien/application/JobApplicationRepository.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/application/JobApplicationRepository.java
@@ -106,6 +106,10 @@ public class JobApplicationRepository {
 
             return application;
 
+        } catch (java.sql.SQLIntegrityConstraintViolationException e) {
+            // Race: a concurrent apply for the same (job, designer) won the UNIQUE
+            // constraint — surface a clean duplicate signal instead of a 500.
+            throw new DuplicateApplicationException();
         } catch (SQLException e) {
             throw new RuntimeException("Failed to create job application", e);
         }

--- a/backend/src/main/java/at/ac/fhcampuswien/auth/AuthController.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/auth/AuthController.java
@@ -174,9 +174,9 @@ public class AuthController {
         if (body.linkedin != null) user.linkedin = body.linkedin.trim();
         if (body.instagram != null) user.instagram = body.instagram.trim();
 
-        user.hourlyMin = body.hourlyMin;
-        user.hourlyMax = body.hourlyMax;
-        user.projectMin = body.projectMin;
+        if (body.hourlyMin != null) user.hourlyMin = body.hourlyMin;
+        if (body.hourlyMax != null) user.hourlyMax = body.hourlyMax;
+        if (body.projectMin != null) user.projectMin = body.projectMin;
 
         userRepository.update(user);
 

--- a/backend/src/main/java/at/ac/fhcampuswien/auth/AuthController.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/auth/AuthController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -40,14 +41,14 @@ public class AuthController {
             ));
         }
 
-        String normalizedRole = req.role.trim().toUpperCase();
+        String normalizedRole = req.role.trim().toUpperCase(Locale.ROOT);
         if (!normalizedRole.equals("CLIENT") && !normalizedRole.equals("DESIGNER")) {
             return ResponseEntity.badRequest().body(Map.of(
                     "error", "role must be CLIENT or DESIGNER"
             ));
         }
 
-        String normalizedEmail = req.email.trim().toLowerCase();
+        String normalizedEmail = req.email.trim().toLowerCase(Locale.ROOT);
         if (userRepository.existsByEmail(normalizedEmail)) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of(
                     "error", "email already exists"
@@ -89,7 +90,7 @@ public class AuthController {
             ));
         }
 
-        UserModel user = userRepository.findByEmail(req.email.trim().toLowerCase());
+        UserModel user = userRepository.findByEmail(req.email.trim().toLowerCase(Locale.ROOT));
         if (user == null || !passwordEncoder.matches(req.password, user.passwordHash)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
                     "error", "invalid email or password"

--- a/backend/src/main/java/at/ac/fhcampuswien/auth/AuthController.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/auth/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Locale;
@@ -151,7 +152,7 @@ public class AuthController {
     }
 
     @PutMapping("/me")
-    public ResponseEntity<?> updateProfile(Authentication auth, @RequestBody ProfileUpdateRequest body) {
+    public ResponseEntity<?> updateProfile(Authentication auth, @Valid @RequestBody ProfileUpdateRequest body) {
         if (auth == null || auth.getName() == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "not authenticated"));
         }

--- a/backend/src/main/java/at/ac/fhcampuswien/auth/ProfileUpdateRequest.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/auth/ProfileUpdateRequest.java
@@ -14,7 +14,8 @@ public class ProfileUpdateRequest {
     public String linkedin;
     public String instagram;
 
-    public int hourlyMin;
-    public int hourlyMax;
-    public int projectMin;
+    // Boxed so an omitted field is null (not 0) and a partial update doesn't clobber the stored rate.
+    public Integer hourlyMin;
+    public Integer hourlyMax;
+    public Integer projectMin;
 }

--- a/backend/src/main/java/at/ac/fhcampuswien/auth/ProfileUpdateRequest.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/auth/ProfileUpdateRequest.java
@@ -1,18 +1,21 @@
 package at.ac.fhcampuswien.auth;
 
+import jakarta.validation.constraints.Size;
+
+// @Size caps mirror the users-table VARCHAR limits, so over-long input is a 400, not an H2 500 (B24).
 public class ProfileUpdateRequest {
-    public String fullName;
-    public String designType;
-    public String bio;
-    public String country;
-    public String city;
-    public String availability;
-    public String skills;
-    public String portfolioVisibility;
-    public String portfolioUrl;
-    public String twitter;
-    public String linkedin;
-    public String instagram;
+    @Size(max = 255) public String fullName;
+    @Size(max = 255) public String designType;
+    @Size(max = 2000) public String bio;
+    @Size(max = 255) public String country;
+    @Size(max = 255) public String city;
+    @Size(max = 50) public String availability;
+    @Size(max = 1000) public String skills;
+    @Size(max = 50) public String portfolioVisibility;
+    @Size(max = 500) public String portfolioUrl;
+    @Size(max = 255) public String twitter;
+    @Size(max = 500) public String linkedin;
+    @Size(max = 255) public String instagram;
 
     // Boxed so an omitted field is null (not 0) and a partial update doesn't clobber the stored rate.
     public Integer hourlyMin;

--- a/backend/src/main/java/at/ac/fhcampuswien/auth/UserRepository.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/auth/UserRepository.java
@@ -114,7 +114,8 @@ public class UserRepository {
     }
 
     public UserModel findByEmail(String email) {
-        String sql = "SELECT * FROM users WHERE email = ?";
+        // Exclude soft-deleted (anonymized) accounts so they can't log in / be fetched (B23).
+        String sql = "SELECT * FROM users WHERE email = ? AND role <> 'DELETED'";
         try (Connection connection = Database.getConnection();
              PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, email);
@@ -130,7 +131,8 @@ public class UserRepository {
     }
 
     public UserModel findById(String id) {
-        String sql = "SELECT * FROM users WHERE id = ?";
+        // Exclude soft-deleted (anonymized) accounts (B23).
+        String sql = "SELECT * FROM users WHERE id = ? AND role <> 'DELETED'";
         try (Connection connection = Database.getConnection();
              PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, id);

--- a/backend/src/main/java/at/ac/fhcampuswien/config/RequestLoggingConfig.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/config/RequestLoggingConfig.java
@@ -23,8 +23,11 @@ public class RequestLoggingConfig {
         filter.setIncludeClientInfo(true);
         filter.setIncludeQueryString(true);
         filter.setIncludeHeaders(true);
-        filter.setIncludePayload(true);
-        filter.setMaxPayloadLength(10_000);
+        // Never log credentials: drop the Authorization (bearer JWT) and Cookie headers,
+        // and don't log request bodies — login/register payloads carry plaintext passwords (H6).
+        filter.setHeaderPredicate(headerName ->
+                !headerName.equalsIgnoreCase("authorization") && !headerName.equalsIgnoreCase("cookie"));
+        filter.setIncludePayload(false);
         filter.setAfterMessagePrefix("HTTP REQUEST: ");
         return filter;
     }

--- a/backend/src/main/java/at/ac/fhcampuswien/config/WebConfig.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/config/WebConfig.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -12,16 +11,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${app.frontend.path:../frontend/design1/}")
     private String frontendPath;
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins(
-                        "http://localhost:63342",
-                        "http://127.0.0.1:63342"
-                )
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*");
-    }
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/**")

--- a/backend/src/main/java/at/ac/fhcampuswien/config/WebConfig.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/config/WebConfig.java
@@ -8,7 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    @Value("${app.frontend.path:../frontend/design1/}")
+    @Value("${app.frontend.path:../frontend/design3/}")
     private String frontendPath;
 
     @Override

--- a/backend/src/main/java/at/ac/fhcampuswien/external/ExternalLocationApiClient.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/external/ExternalLocationApiClient.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -17,12 +18,15 @@ import java.util.List;
 public class ExternalLocationApiClient {
 
     private static final String CITIES_API_URL = "https://countriesnow.space/api/v0.1/countries/cities";
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
 
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
 
     public ExternalLocationApiClient() {
         this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
                 .followRedirects(HttpClient.Redirect.ALWAYS)
                 .build();
         this.objectMapper = new ObjectMapper();
@@ -38,6 +42,7 @@ public class ExternalLocationApiClient {
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(CITIES_API_URL))
+                    .timeout(REQUEST_TIMEOUT)
                     .header("Content-Type", "application/json")
                     .header("Accept", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))

--- a/backend/src/main/java/at/ac/fhcampuswien/external/ExternalTimeApiClient.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/external/ExternalTimeApiClient.java
@@ -11,17 +11,22 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 @Component
 public class ExternalTimeApiClient {
 
     private static final String BASE_URL = "https://www.timeapi.io/api/Time/current/zone?timeZone=";
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
 
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
 
     public ExternalTimeApiClient(ObjectMapper objectMapper) {
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .build();
         this.objectMapper = objectMapper;
     }
 
@@ -32,6 +37,7 @@ public class ExternalTimeApiClient {
 
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(uri)
+                    .timeout(REQUEST_TIMEOUT)
                     .GET()
                     .build();
 

--- a/backend/src/main/java/at/ac/fhcampuswien/job/JobController.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/job/JobController.java
@@ -52,6 +52,10 @@ public class JobController {
         }
 
         job.clientId = auth.getName();
+        // Never trust a client-supplied id/createdAt on create — they'd let a caller force a
+        // PRIMARY KEY collision (500) or forge the sort order. Let the repository generate them.
+        job.id = null;
+        job.createdAt = null;
 
         Job savedJob = jobRepository.create(job);
 

--- a/backend/src/main/java/at/ac/fhcampuswien/job/JobController.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/job/JobController.java
@@ -51,6 +51,12 @@ public class JobController {
             ));
         }
 
+        if (!isClient(auth)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of(
+                    "error", "only clients can post jobs"
+            ));
+        }
+
         job.clientId = auth.getName();
         // Never trust a client-supplied id/createdAt on create — they'd let a caller force a
         // PRIMARY KEY collision (500) or forge the sort order. Let the repository generate them.
@@ -193,5 +199,13 @@ public class JobController {
         return ResponseEntity.ok(Map.of(
                 "message", "job deleted successfully"
         ));
+    }
+
+    private boolean isClient(Authentication auth) {
+        return auth.getAuthorities().stream()
+                .anyMatch(authority ->
+                        "CLIENT".equals(authority.getAuthority())
+                                || "ROLE_CLIENT".equals(authority.getAuthority())
+                );
     }
 }

--- a/backend/src/main/java/at/ac/fhcampuswien/worldclock/WorldClockService.java
+++ b/backend/src/main/java/at/ac/fhcampuswien/worldclock/WorldClockService.java
@@ -30,6 +30,12 @@ public class WorldClockService {
     private WorldClockResponse loadCityTime(String city, String timezone) {
         JsonNode apiResponse = externalTimeApiClient.getCurrentTimeForTimezone(timezone);
 
+        // The client returns null when the upstream API fails or times out — degrade
+        // per city instead of NPE-ing the whole /world-clock response.
+        if (apiResponse == null) {
+            return new WorldClockResponse(city, timezone, "", "", "");
+        }
+
         String date = apiResponse.path("date").asText("");
         String time = apiResponse.path("time").asText("");
         String dayOfWeek = apiResponse.path("dayOfWeek").asText("");

--- a/backend/src/test/java/at/ac/fhcampuswien/application/ApplicationControllerTest.java
+++ b/backend/src/test/java/at/ac/fhcampuswien/application/ApplicationControllerTest.java
@@ -247,7 +247,7 @@ class ApplicationControllerTest {
         app.status = "PENDING";
         JobApplication updated = new JobApplication();
         updated.status = "ACCEPTED";
-        when(repository.updateStatus("app-1", "ACCEPTED")).thenReturn(updated);
+        when(repository.updateStatusFrom("app-1", "PENDING", "ACCEPTED")).thenReturn(updated);
 
         ResponseEntity<?> response =
                 controller.updateStatus("app-1", Map.of("status", "ACCEPTED"), auth);
@@ -299,11 +299,11 @@ class ApplicationControllerTest {
         app.status = "ACCEPTED";
         JobApplication hired = new JobApplication();
         hired.status = "HIRED";
-        when(repository.updateStatus("app-1", "HIRED")).thenReturn(hired);
+        when(repository.updateStatusFrom("app-1", "ACCEPTED", "HIRED")).thenReturn(hired);
 
         ResponseEntity<?> response = controller.hire("app-1", auth);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        verify(repository).updateStatus("app-1", "HIRED");
+        verify(repository).updateStatusFrom("app-1", "ACCEPTED", "HIRED");
     }
 }

--- a/backend/src/test/java/at/ac/fhcampuswien/chat/ChatServiceTest.java
+++ b/backend/src/test/java/at/ac/fhcampuswien/chat/ChatServiceTest.java
@@ -20,8 +20,6 @@ class ChatServiceTest {
 
     @Mock ConversationRepository conversationRepository;
     @Mock MessageRepository messageRepository;
-    @Mock ExternalChatApiClient externalChatApiClient;
-
     @InjectMocks ChatService chatService;
 
     private Conversation conversation(String client, String designer, String job) {
@@ -137,6 +135,5 @@ class ChatServiceTest {
         chatService.listConversations("u1");
 
         verify(conversationRepository).findByUserId("u1");
-        verify(externalChatApiClient, never()).listConversations(any());
     }
 }

--- a/backend/src/test/java/at/ac/fhcampuswien/job/JobControllerTest.java
+++ b/backend/src/test/java/at/ac/fhcampuswien/job/JobControllerTest.java
@@ -8,10 +8,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,6 +27,10 @@ class JobControllerTest {
     @Mock Authentication auth;
 
     @InjectMocks JobController controller;
+
+    private void authorizeAs(String authority) {
+        doReturn(List.of(new SimpleGrantedAuthority(authority))).when(auth).getAuthorities();
+    }
 
     @Test
     void create_rejectsUnauthenticated_with401() {
@@ -49,6 +57,7 @@ class JobControllerTest {
     @Test
     void create_setsClientIdFromAuth_notFromBody() {
         when(auth.getName()).thenReturn("client-1");
+        authorizeAs("ROLE_CLIENT");
         when(jobRepository.create(any())).thenAnswer(inv -> inv.getArgument(0));
 
         Job job = new Job();
@@ -59,6 +68,20 @@ class JobControllerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(((Job) response.getBody()).clientId).isEqualTo("client-1");
+    }
+
+    @Test
+    void create_rejectsDesigner_with403() {
+        when(auth.getName()).thenReturn("designer-1");
+        authorizeAs("ROLE_DESIGNER");
+
+        Job job = new Job();
+        job.title = "Logo";
+
+        ResponseEntity<?> response = controller.create(job, auth);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        verify(jobRepository, never()).create(any());
     }
 
     @Test

--- a/frontend/design3/advanced-search.html
+++ b/frontend/design3/advanced-search.html
@@ -147,7 +147,7 @@
                     <label for="t-remote" class="font-monospace text-uppercase fw-bold">Remote</label>
                   </div>
                   <div class="check-tile">
-                    <input type="checkbox" name="type" value="onsite" id="t-onsite">
+                    <input type="checkbox" name="type" value="on site" id="t-onsite">
                     <label for="t-onsite" class="font-monospace text-uppercase fw-bold">On-Site</label>
                   </div>
                   <div class="check-tile">

--- a/frontend/design3/index.html
+++ b/frontend/design3/index.html
@@ -201,6 +201,9 @@
     });
 
     window.addEventListener("message", event => {
+      // Only trust messages from our own origin — otherwise any framed/foreign page
+      // could drive navigate() to an attacker URL (F8).
+      if (event.origin !== window.location.origin) return;
       if (event.data && event.data.type === "auth-changed") {
         updateAuthNavigation();
 

--- a/frontend/design3/login.html
+++ b/frontend/design3/login.html
@@ -112,12 +112,18 @@
 <script src="auth.js"></script>
 
 <script>
+    // Accept only a same-origin relative path as a post-login redirect target;
+    // reject javascript:/data: and off-site (//host) URLs — open-redirect/XSS (F2).
+    function safeNext(raw) {
+        if (!raw || raw.includes(":") || raw.startsWith("//")) return "homepage.html";
+        return raw;
+    }
+
     // If the user is already authenticated (token in localStorage, not expired),
     // skip the form and bounce straight to the homepage — closes US-04.
     if (window.Auth && Auth.isAuthenticated()) {
         const params = new URLSearchParams(window.location.search);
-        const next = params.get("next");
-        window.location.replace(next || "homepage.html");
+        window.location.replace(safeNext(params.get("next")));
     }
 
     // Surface a hint when we were redirected here because a token expired.
@@ -171,12 +177,12 @@
             message.className = "font-monospace small mb-3 text-success";
 
             const params = new URLSearchParams(window.location.search);
-            const next = params.get("next");
+            const next = safeNext(params.get("next"));
 
 // Tell the parent index.html that the login state changed.
             window.parent.postMessage({ type: "auth-changed" }, "*");
 
-            window.location.href = next || "homepage.html";
+            window.location.href = next;
         } catch (error) {
             console.error("Login error:", error);
             message.textContent = "Login request failed. Please check if the backend is running.";

--- a/frontend/design3/search-results.js
+++ b/frontend/design3/search-results.js
@@ -115,7 +115,7 @@ function mapBudgetToBackendValue(value) {
   const budgets = {
     "1": "small",
     "2": "medium",
-    "3": "large"
+    "3": "big"      // matches the value post-a-job.html stores (not "large")
   };
 
   return budgets[value] || value;


### PR DESCRIPTION
## Summary

16 bug fixes from the `bugHunt` pass, each a separate commit. Full suite is **green on this branch (116 tests, 0 failures)**; every backend change was `mvn compile`/`mvn test`-verified.

### Backend — correctness / security
- **B15/B25** — connect+request timeouts on both external HTTP clients; `WorldClockService` degrades per-city on a `null` time-API response instead of NPE-ing.
- **B23** — `findByEmail`/`findById` exclude soft-deleted (`role='DELETED'`) accounts.
- **B24** — boxed `Integer` rates (no partial-PUT clobber) **and** `@Size`/`@Valid` length validation (over-long input → 400, not 500).
- **B17** — removed the duplicate `WebConfig` CORS source.
- **B20** — `app.frontend.path` default `design1`→`design3`.
- **B19** — atomic application status/hire transitions (`UPDATE … WHERE status=?` → 409 on lost race).
- **H6** — request logger no longer writes passwords / bearer JWTs.
- POST `/jobs` — server-generates `id`/`createdAt`; **blocks non-clients** (403).
- Duplicate-apply race → **409** instead of 500.
- `Locale.ROOT` email/role normalization.

### Build
- Fixed `ChatServiceTest` referencing the removed external-chat client (the suite couldn't compile).

### Frontend
- **F2** — login `next` validated (`safeNext`); **F8** — shell `message` `event.origin` check; **F4** — search budget `large`→`big`, work-mode `onsite`→`on site`.

## Not addressed here (newer than this branch)
This branch predates TachyonCc's Pexels + view-count commits, so it does **not** fix **B26** (malformed `UPDATE jobs` SQL → every `PUT /jobs/{id}` 500s) or **B27** (Pexels hardcoded key / wildcard CORS / no timeout / public `/api/**`). After merge, the now-compiling `JobRepositoryTest.update` will fail until B26 is fixed. See `reviewsANDguides/review-13.06.26.md`.

## Test plan
- [ ] `cd backend && mvn test` → resolve B26 so the suite is green
- [ ] Rotate the committed Pexels key (B27)